### PR TITLE
Reset Queue config, if already set

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -25,8 +25,17 @@ class Plugin extends BasePlugin
 
         $app->addPlugin('Josegonzalez/CakeQueuesadilla');
 
+        $config = Configure::read('Queuesadilla');
+
+        // Reset Queue config
+        foreach ($config as $configName => $settings) {
+            if (!is_null(Queue::getConfig($configName))) {
+                Queue::drop($configName);
+            }
+        }
+
         // Load Queue config
-        Queue::setConfig(Configure::read('Queuesadilla'));
+        Queue::setConfig($config);
 
         if (!defined('SIGQUIT')) {
             define('SIGQUIT', 'SIGQUIT');


### PR DESCRIPTION
## Problem
If a UnitTest is using the `IntegrationTestTrait` with `MiddlewareDispatcher`, on each Request the `Cake\Http\Server` will bootstrap all plugins (`$this->app->pluginBootstrap();`, in method `bootstrap`).

On each bootstrap we try to set the config for `Queue`, which results in a `BadMethodCallException` inside the `StaticConfigTrait`

## Solution
Resetting the `Queue`-config before setting it. 